### PR TITLE
Fix misspelt deprecated OccurenceOrderPlugin

### DIFF
--- a/src/createWebpackConfig.js
+++ b/src/createWebpackConfig.js
@@ -237,7 +237,7 @@ export function createPlugins(server, cwd, {
       ...define
     }),
     new optimize.DedupePlugin(),
-    new optimize.OccurenceOrderPlugin()
+    new optimize.OccurrenceOrderPlugin()
   ]
 
   // Assumption: we're always hot reloading if we're bundling on the server


### PR DESCRIPTION
It is removed in Webpack 2, and is now named `OccurrenceOrderPlugin`.