### PR TITLE
Dev server can listen to a specified hostname

### DIFF
--- a/src/devServer.js
+++ b/src/devServer.js
@@ -13,7 +13,7 @@ import webpack from 'webpack'
  * If static path config is also provided, express will also be used to serve
  * static content from the given path.
  */
-export default function server(webpackConfig, {fallback, noInfo, port, staticPath}, cb) {
+export default function server(webpackConfig, {fallback, noInfo, hostname, port, staticPath}, cb) {
   let app = express()
   let compiler = webpack(webpackConfig)
 
@@ -46,8 +46,8 @@ export default function server(webpackConfig, {fallback, noInfo, port, staticPat
     })
   }
 
-  app.listen(port, 'localhost', err => {
+  app.listen(port, hostname, err => {
     if (err) return cb(err)
-    console.log(chalk.green(`nwb: dev server listening at http://localhost:${port}`))
+    console.log(chalk.green(`nwb: dev server listening at http://${hostname}:${port}`))
   })
 }

--- a/src/webpackServer.js
+++ b/src/webpackServer.js
@@ -18,6 +18,7 @@ export default function(args, buildConfig, cb) {
   devServer(webpackConfig, {
     fallback: !!args.fallback,
     noInfo: !args.info,
+    hostname: args.hostname || 'localhost',
     port: args.port || 3000,
     staticPath: server.staticPath
   }, cb)


### PR DESCRIPTION
This PR will let `nwb serve` handle a hostname argument which will be passed to webpack dev server to listen to the specified hostname. If the hostname is not specified, `localhost` will be used.   

**Usage**
`nwb serve --hostname=<hostname>`

**Example**
`nwb serve --hostname=0.0.0.0`
`nwb serve --hostname=mydomain`