### PR TITLE
Use getElementById instead of querySelector

### DIFF
--- a/templates/react-app/src/index.js
+++ b/templates/react-app/src/index.js
@@ -3,4 +3,4 @@ import {render} from 'react-dom'
 
 import App from './App'
 
-render(<App/>, document.querySelector('#app'))
+render(<App/>, document.getElementById('app'))

--- a/templates/web-app/src/index.js
+++ b/templates/web-app/src/index.js
@@ -1,3 +1,3 @@
-let app = document.querySelector('#app')
+let app = document.getElementById('app')
 
 app.innerHTML = '<h2>Welcome to {{name}}</h2>'


### PR DESCRIPTION
- There is a slight (arguably negligible) performance improvement if we
use `getElementById` instead of `querySelector` since we know we're
looking for an element by ID.