### PR TITLE
Allow react run to serve an exported component

### DIFF
--- a/src/commands/serve-react.js
+++ b/src/commands/serve-react.js
@@ -24,22 +24,37 @@ export default function serveReact_(args, cb) {
   }
 
   let entry = args._[1]
+  let mountId = args['mount-id'] || 'app'
 
   serveReact(args, {
     babel: {
       stage: 0,
     },
-    entry: [path.resolve(entry)],
+    // Use a dummy entry module to try to render what was exported if nothing
+    // has been rendered after importing the provided entry module.
+    entry: [require.resolve('../reactRunEntry')],
     output: {
       filename: 'app.js',
       path: process.cwd(),
       publicPath: '/',
     },
     plugins: {
+      define: {
+        NWB_REACT_RUN_MOUNT_ID: JSON.stringify(mountId)
+      },
       html: {
-        mountId: args['mount-id'] || 'app',
+        mountId,
         title: args.title || 'React App',
       },
     },
+    resolve: {
+      alias: {
+        // Allow the dummy entry module to import the provided entry module
+        'nwb-react-run-entry': path.resolve(entry),
+        // Allow the dummy entry module to resolve React and ReactDOM from the cwd
+        'react': path.dirname(resolve.sync('react', {basedir: process.cwd()})),
+        'react-dom': path.dirname(resolve.sync('react-dom', {basedir: process.cwd()})),
+      }
+    }
   }, cb)
 }

--- a/src/reactRunEntry.js
+++ b/src/reactRunEntry.js
@@ -1,0 +1,32 @@
+import Component from 'nwb-react-run-entry'
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+let alreadyRendered = document.getElementById(NWB_REACT_RUN_MOUNT_ID).childNodes.length > 0 // eslint-disable-line no-undef
+
+function render(Component) {
+  // Don't attempt to render if there was already something rendered,
+  // or if nothing was exported (assumption: they rendered somewhere else and
+  // didn't export anything)
+  if (alreadyRendered ||
+      !(typeof Component === 'function' || Object.keys(Component).length > 0)) {
+    return
+  }
+
+  // Assumption: either a React component or element was exported
+  // If a React component was exported, create an element
+  if (typeof Component === 'function' || !(Component.type && Component.props)) {
+    Component = React.createElement(Component)
+  }
+
+  // Component should now be a React element
+  ReactDOM.render(Component, document.getElementById(NWB_REACT_RUN_MOUNT_ID)) // eslint-disable-line no-undef
+}
+
+render(Component)
+
+if (module.hot) {
+  module.hot.accept('nwb-react-run-entry', () => {
+    render(require('nwb-react-run-entry'))
+  })
+}


### PR DESCRIPTION
This PR uses a dummy entry module is pretty much the same as the one in [react-heatpack](https://github.com/insin/react-heatpack) to allow nwb's `react run` command to render modules which export a React component or element.