### PR TITLE
Documentation - Fixes broken link to browserl.ist

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -311,7 +311,7 @@ module.exports = {
 }
 ```
 
-You can check which browsers your Autoprefixer configuration will target using the [browserl.ist](browserl.ist) service.
+You can check which browsers your Autoprefixer configuration will target using the [browserl.ist](http://browserl.ist) service.
 
 ##### `compat`: `Object`
 


### PR DESCRIPTION
Without this change the link would go to `https://github.com/insin/nwb/blob/master/docs/browserl.ist`.