### PR TITLE
Require is not needed

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -150,7 +150,7 @@ module.exports = {
   karma: {
     testContext: 'tests.webpack.js'
     plugins: [
-      require('karma-chai')
+      'karma-chai'
     ],
     frameworks: ['mocha', 'chai']
   }


### PR DESCRIPTION
Plug-ins don't need to be wrapped in require as Karma does this automatically for you https://karma-runner.github.io/1.0/config/plugins.html