### PR TITLE
Fix preact-app Test

### DIFF
--- a/templates/preact-app/tests/App-test.js
+++ b/templates/preact-app/tests/App-test.js
@@ -16,6 +16,6 @@ describe('App component', () => {
 
   it('displays a welcome message', () => {
     render(<App/>, node)
-    expect(node.textContent).toContain('Welcome to Preact')
+    expect(node.textContent).toContain('Welcome to')
   })
 })


### PR DESCRIPTION
When you create a fresh, new preact app and run the test with `npm run test`, the test will fail because the expected message 'Welcome to Preact' is not in the textContent

![screenshot at dez 10 20-18-48](https://cloud.githubusercontent.com/assets/8714775/21075601/735d33c0-bf16-11e6-8c08-f0128c7ba10b.png)

To get the pre-created test pass, i removed the word Preact, because it's an image -> https://github.com/insin/nwb/blob/master/templates/preact-app/src/App.js#L10

![2](https://cloud.githubusercontent.com/assets/8714775/21075627/d6397e7c-bf16-11e6-840a-3d71d0064b9d.png)
