### PR TITLE
Fir broken link markup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cd my-module/
 
 - [Developing React Apps with nwb](/docs/guides/ReactApps.md)
 - [Developing React Components and Libraries with nwb](/docs/guides/ReactComponents.md#developing-react-components-and-libraries-with-nwb)
-- [Switching to nwb from create-react-app][https://github.com/insin/nwb-from-create-react-app/] (as an alternative to ejecting if you need configuration)
+- [Switching to nwb from create-react-app](https://github.com/insin/nwb-from-create-react-app/) (as an alternative to ejecting if you need configuration)
 
 ## [Documentation](/docs/#table-of-contents)
 


### PR DESCRIPTION
Link for "Switching to nwb from create-react-app" is not correctly formatted, and because it has annotation in parentheses after itself, it points to 404 page.