### PR TITLE
add resolve.alias to the inferno build quick command (fix)

### DIFF
--- a/src/commands/build-inferno.js
+++ b/src/commands/build-inferno.js
@@ -40,6 +40,12 @@ function buildConfig(args) {
       // A vendor bundle must be explicitly enabled with a --vendor flag
       vendor: args.vendor,
     },
+    resolve: {
+      alias: {
+        'react': 'inferno-compat',
+        'react-dom': 'inferno-compat'
+      }
+    }
   }
 
   if (args.force === true) {


### PR DESCRIPTION
Fix for issue #241



<!--
Are you using the appropriate branch?

`master` is used for bug fixes, documentation changes and any other changes which should be made available soon after being committed.

`next` is generally used for development of new features for the next major release and tracking dependency updates until then.

`webpack2` is being used for changes required to switch over to Webpack 2 once it's officially released. This branch gets rebased frequently.
-->
