### PR TITLE
Exit process on command callback when no error

### DIFF
--- a/src/bin/nwb.js
+++ b/src/bin/nwb.js
@@ -27,6 +27,7 @@ function handleError(error) {
 try {
   cli(process.argv.slice(2), err => {
     if (err) handleError(err)
+    process.exit(0)
   })
 }
 catch (e) {


### PR DESCRIPTION
I've added a change to exit the process in the cli command callback. In the current version the process only exits if an error occurs.

I picked this up when setting up testing on a TeamCity integration server. Without the process.exit, the karma node process hangs around forever and the build doesn't finish. After digging around the karma docs, I found out when no callback is passed on starting the karma server, karma will use process.exit. 

_Thanks for a great project. It's just the right balance of configuration and convention, and has saved me a ton of setup time._