### PR TITLE
Replacing mistyped 'npm' with 'nwb'

### DIFF
--- a/templates/react-component/_package.json
+++ b/templates/react-component/_package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "nwb build-react-component",
-    "clean": "nwb clean-module && npm clean-demo",
+    "clean": "nwb clean-module && nwb clean-demo",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",


### PR DESCRIPTION
**templates/react-component/_package.json** `clean` script is using `npm` rather than `nwb` to run `clean-demo`