### PR TITLE
Chrome generic

### DIFF
--- a/src/createKarmaConfig.js
+++ b/src/createKarmaConfig.js
@@ -107,7 +107,8 @@ export function getKarmaPluginConfig({codeCoverage = false, userConfig = {}} = {
   if (browsers.indexOf('PhantomJS') !== -1 && !findPlugin(plugins, 'launcher:PhantomJS')) {
     plugins.push(require('karma-phantomjs-launcher'))
   }
-  if (browsers.indexOf('Chrome') !== -1 && !findPlugin(plugins, 'launcher:Chrome')) {
+  if (browsers.some(function matchChrom(b) { return /Chrom/.test(b); }) &&
+      !findPlugin(plugins, 'launcher:Chrome')) {
     plugins.push(require('karma-chrome-launcher'))
   }
 

--- a/src/createKarmaConfig.js
+++ b/src/createKarmaConfig.js
@@ -107,7 +107,7 @@ export function getKarmaPluginConfig({codeCoverage = false, userConfig = {}} = {
   if (browsers.indexOf('PhantomJS') !== -1 && !findPlugin(plugins, 'launcher:PhantomJS')) {
     plugins.push(require('karma-phantomjs-launcher'))
   }
-  if (browsers.some(function matchChrom(b) { return /Chrom/.test(b); }) &&
+  if (browsers.some(function matchChrom(b) { return /Chrom/.test(b) }) &&
       !findPlugin(plugins, 'launcher:Chrome')) {
     plugins.push(require('karma-chrome-launcher'))
   }


### PR DESCRIPTION
`karma-chrome-launcher` already supports `Chromium` and `ChromeCanary` by default; and it is anticipated that users may specify `customLaunchers` that use `Chrome`, `ChromeCanary`, or `Chromium` as their `base`, with names typically beginning with `'Chrome...'`.

See:  https://github.com/karma-runner/karma-chrome-launcher#configuration

By testing browser strings for a match on `/Chrom/`, the plugin gets loaded for any of the above. So, for example, I can have this in my `nwb.config.js`:

```js
module.exports = {
  ...,
  karma: {
          browsers: ['Chrome_headless'],
          extra: {
              customLaunchers: {
                  Chrome_headless: {
                      base: 'ChromeCanary',
                      flags: ['--headless', '--remote-debugging-port=9222', 'http://0.0.0.0:9876/']
                  }
              }
          }
      },
  ...
};
```

I'm using that locally now, with a locally patched `nwb`, on macOS with standard Chrome Canary installation (copied into `/Applications` folder) — works well!

I'm making this pull request to master as not supporting a built-in feature of the karma launcher seems like a bug to me.