### PR TITLE
Fix bug that causes `webpack.styles=false` to fail.

### DIFF
--- a/src/getUserConfig.js
+++ b/src/getUserConfig.js
@@ -492,7 +492,7 @@ export function processUserConfig({
         `Must be ${chalk.green("'old'")}, ${chalk.green('false')} (to disable default style rules) or an Object.`
       )
     }
-    else if (configType !== 'object') {
+    else if (configType !== 'object' && configType !== 'boolean') {
       report.error(
         'webpack.styles',
         `type: ${configType}`,


### PR DESCRIPTION
There's a type-testing bug in `getUserConfig.js` that prevents `webpack.styles` from being able to be set to `false`, like the documentation says it should be able to be.  The previous if-condition correctly falls-through to the if-condition on line 495, which then incorrectly fails because the type doesn't match `object`.

This pull request contains a simple one-line fix for the bug.  Tested locally, and it works as expected.  Cheers!  :-)