### PR TITLE
Add --no-html flag for people who will handle that themselves

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -182,6 +182,7 @@ Passing arguments for `entry` and `dist_dir` allows you to customise the entry p
 Default behaviour:
 
 - A static build will be created in `dist/`, with app `.js` and `.css` files plus any other resources used.
+- As part of the static build an `.html` page will be included in `dist/`. You can disable this by passing a `--no-html` flag.
 - Separate vendor `.js` and `.css` files will be built for any dependencies imported from `node_modules/`. You can disable this by passing a `--no-vendor` flag.
 - Static builds are created in production mode. Code will be minified and have dead code elimination performed on it (for example to remove unreachable, or development-mode only, code).
 - To support long-term caching, generated `.js` and `.css` filenames will contain a deterministic hash, which will only change when the contents of the files change.

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -31,7 +31,7 @@ export function getBuildCommandConfig(args, extra = {}) {
       publicPath: '/',
     },
     plugins: {
-      html: getDefaultHTMLConfig(),
+      html: args.html !== false && getDefaultHTMLConfig(),
       vendor: args.vendor !== false,
     },
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -79,6 +79,7 @@ Generic project development commands:
     Clean and build the project.
 
     Options:
+      ${opt('--no-html')}    disable creation of default '.html' configuration
       ${opt('--no-vendor')}  disable creation of 'vendor' bundle for node_modules/ modules
 
   ${cmd('nwb clean')}


### PR DESCRIPTION

<!--
Are you using the appropriate branch?

`master` is used for bug fixes, documentation changes and any other changes which should be made available soon after being committed.

`next` is generally used for development of new features for the next major release and tracking dependency updates until then.
-->
