### PR TITLE
Fix missing colons in Configuration docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -197,7 +197,7 @@ e.g. to disable loose mode only when running tests:
 
 ```js
 module.exports = {
-  babel {
+  babel: {
     loose: process.env.NODE_ENV === 'test'
   }
 }
@@ -305,7 +305,7 @@ e.g. if you want to use export extensions in your app, you should set `stage` to
 
 ```js
 module.exports = {
-  babel {
+  babel: {
     stage: 1
   }
 }
@@ -315,7 +315,7 @@ Stage 2 is enabled by default - to disable use of a stage preset entirely, set `
 
 ```js
 module.exports = {
-  babel {
+  babel: {
     stage: false
   }
 }


### PR DESCRIPTION
There were three typos in the Configuration docs, where a colon was missing in code examples.

Before:

```js
module.exports = {
  babel {
    ...
```

After:


```js
module.exports = {
  babel: {
    ...
```



<!--
Are you using the appropriate branch?

`master` is used for critical fixes, documentation changes for the current version and any other changes which should be made available soon after being committed.

`next` is generally used for development of new features for the next major release and tracking non-critical dependency updates until the next release is ready.
-->
