### PR TITLE
Add __mocks__ directory to Babel ignore config

### DIFF
--- a/src/moduleBuild.js
+++ b/src/moduleBuild.js
@@ -23,7 +23,8 @@ const DEFAULT_BABEL_IGNORE_CONFIG = [
   '.spec.js',
   '.test.js',
   '-test.js',
-  '/__tests__/'
+  '/__tests__/',
+  '/__mocks__/'
 ]
 
 /**

--- a/tests/commands/build-test.js
+++ b/tests/commands/build-test.js
@@ -84,6 +84,10 @@ describe('command: build', function() {
       cli(['new', 'react-component', 'test-component', '--umd=TestComponent', '--es-modules'], (err) => {
         expect(err).toNotExist('No errors creating a new React component')
         process.chdir(path.join(tmpDir, 'test-component'))
+
+        // Create test file. It should not be on the build directories
+        fs.writeFileSync(path.join('src', 'test-component.test.js'), '')
+
         cli(['build'], (err) => {
           expect(err).toNotExist()
           done(err)

--- a/tests/commands/build-test.js
+++ b/tests/commands/build-test.js
@@ -85,8 +85,10 @@ describe('command: build', function() {
         expect(err).toNotExist('No errors creating a new React component')
         process.chdir(path.join(tmpDir, 'test-component'))
 
-        // Create test file. It should not be on the build directories
+        // Create test files. They should not be on the build directories
         fs.writeFileSync(path.join('src', 'test-component.test.js'), '')
+        fs.mkdirSync(path.join('src', '__mocks__'))
+        fs.writeFileSync(path.join('src', '__mocks__', 'test-component.js'), '')
 
         cli(['build'], (err) => {
           expect(err).toNotExist()


### PR DESCRIPTION
I'm currently using nwb, but I'm using Jest as my test framework.

Currently, the build doesn't remove the `__mocks__` from the build. That leads to a Jest error:

```
jest-haste-map: duplicate manual mock found:
  Module name: newAddress
  Duplicate Mock path: /Users/breno/Projects/address-form-lib/src/__mocks__/newAddress.js
This warning is caused by two manual mock files with the same file name.
Jest will use the mock file found in:
/Users/breno/Projects/address-form-lib/src/__mocks__/newAddress.js
 Please delete one of the following two files:
 /Users/breno/Projects/address-form-lib/lib/__mocks__/newAddress.js
/Users/breno/Projects/address-form-lib/src/__mocks__/newAddress.js
```

Also, the mock files are being published to npm, which isn't ideal.

