### PR TITLE
Update devServer config to include CORS header

### DIFF
--- a/src/devServer.js
+++ b/src/devServer.js
@@ -17,6 +17,9 @@ export default function devServer(webpackConfig, serverConfig, cb) {
   let {host, port, ...otherServerConfig} = serverConfig
 
   let webpackDevServerOptions = merge({
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    },
     historyApiFallback: true,
     hot: true,
     noInfo: true,


### PR DESCRIPTION
If the 'Access-Control-Allow-Origin' header is not specified, then hot module replacement won't work for projects that use HMR from a different domain (or a different localhsot port)
fixes #356



<!--
Are you using the appropriate branch?

`master` is used for critical fixes, documentation changes for the current version and any other changes which should be made available soon after being committed.

`next` is generally used for development of new features for the next major release and tracking non-critical dependency updates until the next release is ready.
-->
