### PR TITLE
Docs: devServer.setup [deprecated] → devServer.before

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -882,7 +882,7 @@ Notable features you can configure using these options:
 
 - [`devServer.proxy`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) - proxy certain URLs to a separate API backend development server.
 
-- [`devServer.setup`](https://webpack.js.org/configuration/dev-server/#devserver-setup) - access the Express app to add your own middleware to the dev server.
+- [`devServer.before`](https://webpack.js.org/configuration/dev-server/#devserver-before) - access the Express app to add your own middleware to the dev server.
 
 e.g. to enable HTTPS:
 


### PR DESCRIPTION
When using `devServer.setup` (per docs), I get this warning:

> The `setup` option is deprecated and will be removed in v3. Please update your config to use `before`

This PR patches the docs to say `before` instead. :)