### PR TITLE
Fix config validation of `babel.env`

### DIFF
--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -42,7 +42,7 @@ export function processBabelConfig({report, userConfig}) {
 
   // env
   if ('env' in userConfig.babel) {
-    if (typeOf(env) !== 'Object') {
+    if (typeOf(env) !== 'object') {
       report.error(
         'babel.env',
         env,


### PR DESCRIPTION
Test config:

```js
module.exports = {
	babel: {
		env: {
			targets: {
				browsers: ['Chrome 63', 'Firefox ESR', 'Safari 11'],
			},
		}
	}
};
```