### PR TITLE
add prepare scripts

### DIFF
--- a/templates/react-component/_package.json
+++ b/templates/react-component/_package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
+    "prepare": "nwb run build",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",

--- a/templates/react-component/_package.json
+++ b/templates/react-component/_package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
-    "prepare": "nwb run build",
+    "prepublishOnly": "npm run build",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",

--- a/templates/web-module/_package.json
+++ b/templates/web-module/_package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "nwb build-web-module",
     "clean": "nwb clean-module",
-    "prepare": "nwb run build",
+    "prepublishOnly": "npm run build",
     "test": "nwb test",
     "test:coverage": "nwb test --coverage",
     "test:watch": "nwb test --server"

--- a/templates/web-module/_package.json
+++ b/templates/web-module/_package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "nwb build-web-module",
     "clean": "nwb clean-module",
+    "prepare": "nwb run build",
     "test": "nwb test",
     "test:coverage": "nwb test --coverage",
     "test:watch": "nwb test --server"


### PR DESCRIPTION
web-module and react-component should include prepare scripts to automatically build package before publishing to NPM

refs #436 

<!--
Are you using the appropriate branch?

`master` is used for critical fixes, documentation changes for the current version and any other changes which should be made available soon after being committed.

`next` is generally used for development of new features for the next major release and tracking non-critical dependency updates until the next release is ready.
-->
