### PR TITLE
Fix blurry badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,14 +184,11 @@ cd my-module/
 
 *Operating system icons created with [Icons8](https://icons8.com/)*
 
-[travis-badge]: https://img.shields.io/travis/insin/nwb/master.png?style=flat-square
+[travis-badge]: https://img.shields.io/travis/insin/nwb/master.svg?style=flat-square
 [travis]: https://travis-ci.org/insin/nwb
-
-[appveyor-badge]: https://img.shields.io/appveyor/ci/insin/nwb/master.png?style=flat-square
+[appveyor-badge]: https://img.shields.io/appveyor/ci/insin/nwb/master.svg?style=flat-square
 [appveyor]: https://ci.appveyor.com/project/insin/nwb
-
-[npm-badge]: https://img.shields.io/npm/v/nwb.png?style=flat-square
+[npm-badge]: https://img.shields.io/npm/v/nwb.svg?style=flat-square
 [npm]: https://www.npmjs.org/package/nwb
-
-[coveralls-badge]: https://img.shields.io/coveralls/insin/nwb/master.png?style=flat-square
+[coveralls-badge]: https://img.shields.io/coveralls/insin/nwb/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/insin/nwb

--- a/templates/react-component/README.md
+++ b/templates/react-component/README.md
@@ -6,11 +6,11 @@
 
 Describe {{name}} here.
 
-[build-badge]: https://img.shields.io/travis/user/repo/master.png?style=flat-square
+[build-badge]: https://img.shields.io/travis/user/repo/master.svg?style=flat-square
 [build]: https://travis-ci.org/user/repo
 
-[npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square
+[npm-badge]: https://img.shields.io/npm/v/npm-package.svg?style=flat-square
 [npm]: https://www.npmjs.org/package/npm-package
 
-[coveralls-badge]: https://img.shields.io/coveralls/user/repo/master.png?style=flat-square
+[coveralls-badge]: https://img.shields.io/coveralls/user/repo/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/user/repo

--- a/templates/web-module/README.md
+++ b/templates/web-module/README.md
@@ -6,11 +6,11 @@
 
 Describe {{name}} here.
 
-[build-badge]: https://img.shields.io/travis/user/repo/master.png?style=flat-square
+[build-badge]: https://img.shields.io/travis/user/repo/master.svg?style=flat-square
 [build]: https://travis-ci.org/user/repo
 
-[npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square
+[npm-badge]: https://img.shields.io/npm/v/npm-package.svg?style=flat-square
 [npm]: https://www.npmjs.org/package/npm-package
 
-[coveralls-badge]: https://img.shields.io/coveralls/user/repo/master.png?style=flat-square
+[coveralls-badge]: https://img.shields.io/coveralls/user/repo/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/user/repo


### PR DESCRIPTION
The badges used for this project's readme as well as all generated projects are blurry on retina screens. This update replaces the png badges with svg badges so they render clearer on every device.

### Before
<img width="454" alt="screen shot 2018-12-01 at 5 13 42 pm" src="https://user-images.githubusercontent.com/328629/49333507-1e75d500-f58e-11e8-85a6-4d1dbbab76fa.png">

### After
<img width="474" alt="screen shot 2018-12-01 at 5 20 52 pm" src="https://user-images.githubusercontent.com/328629/49333509-25044c80-f58e-11e8-97b5-576de7b8f43d.png">
