### PR TITLE
Add document language option

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -554,6 +554,10 @@ module.exports = {
 
 If you don't have a template at `src/index.html` or specify one via `template`, nwb will fall back to using a basic template which has the following properties you can configure:
 
+- `lang` - the language of document `<html lang=""`>
+
+  > Default: `'en'`
+
 - `title` - contents for `<title>`
 
   > Default: the value of `name` from your app's `package.json`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -554,7 +554,7 @@ module.exports = {
 
 If you don't have a template at `src/index.html` or specify one via `template`, nwb will fall back to using a basic template which has the following properties you can configure:
 
-- `lang` - the language of document `<html lang=""`>
+- `lang` - the language of document `<html lang="">`
 
   > Default: `'en'`
 

--- a/src/appCommands.js
+++ b/src/appCommands.js
@@ -125,6 +125,7 @@ export function getDefaultHTMLConfig(cwd: string = process.cwd()) {
   // Otherwise provide default variables for the internal template, in case we
   // fall back to it.
   return {
+    lang: 'en',
     mountId: 'app',
     title: require(path.join(cwd, 'package.json')).name,
   }

--- a/src/commands/build-demo.js
+++ b/src/commands/build-demo.js
@@ -29,6 +29,7 @@ function getCommandConfig(args) {
     },
     plugins: {
       html: {
+        lang: 'en',
         mountId: 'demo',
         title: args.title || `${pkg.name} ${pkg.version} Demo`,
       },

--- a/src/commands/serve-react-demo.js
+++ b/src/commands/serve-react-demo.js
@@ -24,6 +24,7 @@ export default function serveReactDemo(args, cb) {
     },
     plugins: {
       html: {
+        lang: 'en',
         mountId: 'demo',
         title: `${pkg.name} ${pkg.version} Demo`,
       },

--- a/templates/inferno-app/src/index.html
+++ b/templates/inferno-app/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/templates/preact-app/src/index.html
+++ b/templates/preact-app/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/templates/react-app/src/index.html
+++ b/templates/react-app/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/templates/web-app/src/index.html
+++ b/templates/web-app/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/templates/webpack-template.html
+++ b/templates/webpack-template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= htmlWebpackPlugin.options.lang %>">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION

<!--
Are you using the appropriate branch?

`master` is used for critical fixes, documentation changes for the current version and any other changes which should be made available soon after being committed.

`next` is generally used for development of new features for the next major release and tracking non-critical dependency updates until the next release is ready.
-->

- Add `lang` attribute option to document with `lang="en"` as a default.
