### PR TITLE
Allow usage of array of configs for webpack

### DIFF
--- a/src/devServer.js
+++ b/src/devServer.js
@@ -17,6 +17,12 @@ export default function devServer(webpackConfig, serverConfig, url, cb) {
 
   let {host, open, port, ...otherServerConfig} = serverConfig
 
+  // In case of an array of config, use the first config
+  // as the 'default' config for public path extraction
+  if (Array.isArray(webpackConfig)) {
+    webpackConfig = webpackConfig[0]
+  }
+
   let webpackDevServerOptions = merge({
     headers: {
       'Access-Control-Allow-Origin': '*'

--- a/src/webpackUtils.js
+++ b/src/webpackUtils.js
@@ -82,6 +82,14 @@ function getFileDetails(stats) {
 }
 
 export function logBuildResults(stats, spinner) {
+  // In case of a MultiStats instance, run the function individually for each embedded stat
+  if (stats.stats) {
+    stats.stats.forEach((s) => {
+      logBuildResults(s)
+    })
+    return
+  }
+
   if (stats.hasErrors()) {
     if (spinner) {
       spinner.fail()


### PR DESCRIPTION
Webpack allows users to provide an array of configs instead of a single config.

This PR allows users to provide an array of config through the `webpack.config` configuration hook. 

* In development, it gets the publicPath option for the devServer from the first config, if an array is provided
* In production, it prints the gzipped size information for each configs sequentially


As far as I can tell it doesn't break anything.
All the tests still pass.
