### PR TITLE
Allow to specify Babel CLI extensions argument.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 0.26.0 / 2020-10-20
+## Fixes
+- Allow to specify Babel CLI extensions argument. This makes it possible to compile Typescript components.
+
+
 # 0.25.0 / 2020-05-20
 
 ## Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nwb",
   "description": "A toolkit for React, Preact & Inferno apps, React libraries and other npm modules for the web, with no configuration (until you need it)",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "MIT",
   "author": "Jonny Buchanan <jonathan.buchanan@gmail.com>",
   "bin": {

--- a/src/moduleBuild.js
+++ b/src/moduleBuild.js
@@ -26,7 +26,7 @@ const DEFAULT_BABEL_IGNORE_CONFIG = [
 /**
  * Run Babel with generated config written to a temporary .babelrc.
  */
-function runBabel(name, {copyFiles, outDir, src}, buildBabelConfig, userConfig, cb) {
+function runBabel(name, {copyFiles, outDir, src, extensions}, buildBabelConfig, userConfig, cb) {
   let babelConfig = createBabelConfig(buildBabelConfig, userConfig.babel, userConfig.path)
   babelConfig.ignore = DEFAULT_BABEL_IGNORE_CONFIG
 
@@ -38,6 +38,9 @@ function runBabel(name, {copyFiles, outDir, src}, buildBabelConfig, userConfig, 
   }
 
   fs.writeFile('.babelrc', JSON.stringify(babelConfig, null, 2), (err) => {
+  if (extensions) {
+    args.push('--extensions', extensions)
+  }
     if (err) return cb(err)
     let spinner = ora(`Creating ${name} build`).start()
     let babel = spawn(require.resolve('.bin/babel'), args, {stdio: 'inherit'})
@@ -131,6 +134,7 @@ export default function moduleBuild(args, buildConfig = {}, cb) {
   let babelCliOptions = {
     copyFiles: !!args['copy-files'],
     src: path.resolve('src'),
+    extensions: args['extensions'] || args['x'],
   }
 
   let tasks = [(cb) => cleanModule(args, cb)]


### PR DESCRIPTION
This makes it possible to compile Typescript components.

