### PR TITLE
Don't fail building when there is .babelrc file.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.26.0 / 2020-10-20
+## Fixes
+- Don't fail building when there is .babelrc file. Instead, use .babelrc.build for the temporary config.
+
+  [Babel CLI](https://babeljs.io/docs/en/babel-cli#custom-config-path) allows for `--config-file` option with which you can specify your own config file. Thanks to that, if there is already .babelrc file in the repo, the build can still continue instead of being stopped.
+
 # 0.25.0 / 2020-05-20
 
 ## Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nwb",
   "description": "A toolkit for React, Preact & Inferno apps, React libraries and other npm modules for the web, with no configuration (until you need it)",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "MIT",
   "author": "Jonny Buchanan <jonathan.buchanan@gmail.com>",
   "bin": {


### PR DESCRIPTION
Instead, use .babelrc.build for the temporary config.
Babel CLI v7 allows for --config-file option with which you can specify
your own config file. Thanks to that, if there is already .babelrc file
in the repo, the build can still continue instead of being stopped.

ref: https://babeljs.io/docs/en/babel-cli#custom-config-path

Using babel configuration in nwb.config.js does not pass the specified presets/plugins etc to the demo server.
