### PR TITLE
fix react-app template logo issue

### DIFF
--- a/templates/react-app/src/App.js
+++ b/templates/react-app/src/App.js
@@ -9,7 +9,7 @@ class App extends Component {
         <h2>Welcome to <span className="App-react">React</span></h2>
       </div>
       <div className="App-instructions App-flex">
-        <img className="App-logo" src={require('./react.svg')}/>
+        <img className="App-logo" src={require('./react.svg').default}/>
         <p>Edit <code>src/App.js</code> and save to hot reload your changes.</p>
       </div>
     </div>


### PR DESCRIPTION
issue: can not display react svg logo after new react-app
fix: change require('./react.svg') to require('./react.svg').default

<!--
Are you using the appropriate branch?

`master` is used for critical fixes, documentation changes for the current version and any other changes which should be made available soon after being committed.

`next` is generally used for development of new features for the next major release and tracking non-critical dependency updates until the next release is ready.
-->
